### PR TITLE
Terraform：冗長化構成 ( redundant configuration ) に変更

### DIFF
--- a/Tasks/lecture10/CloudFormation_templates/03_cfn-rds.yml
+++ b/Tasks/lecture10/CloudFormation_templates/03_cfn-rds.yml
@@ -19,6 +19,7 @@ Resources:
       DBInstanceClass: db.t3.micro
       MasterUsername: "{{resolve:ssm:MasterUsername:1}}"
       ManageMasterUserPassword: true
+      AvailabilityZone: !Sub ${AWS::Region}a
       MultiAZ: false
       PubliclyAccessible: false
       Engine: mysql
@@ -47,4 +48,3 @@ Outputs:
     Value: !GetAtt RDSDBInstance.Endpoint.Address
     Export:
       Name: !Sub ${AWS::StackName}-RDSDBEndpoint
-      

--- a/cloudformation/practice01/cfn_practice01.md
+++ b/cloudformation/practice01/cfn_practice01.md
@@ -1,8 +1,8 @@
-# CloudFormation：冗長化構成 ( redundant configuration ) に変更
+# 【 CloudFormation：冗長化構成 ( redundant configuration ) に変更 】
 
 ## ■ 構成図
  - 変更前　( シングルAZ構成 )
- ![](../../Tasks/lecture10/images/resource_diagram.png)
+ ![resource_diagram.png](../../Tasks/lecture10/images/resource_diagram.png)
 
 - 変更後　( マルチAZ構成 )
   ![cfn-practice01.png](./images/cfn-practice01.png)
@@ -60,7 +60,7 @@ $ aws cloudformation deploy --stack-name cfn-s3 --template-file  cloudformation/
   - S3 - Application Layer　( 使用テンプレート：[06_cfn-s3.yml](./cfn_templates_redundant_configuration/06_cfn-s3.yml) )
   ![06_cfn-s3.png](./images/06_cfn-s3.png)
 
-## ■ 検証・気づき・工夫点・備忘録
+## ■ 検証・動作確認・工夫点・備忘録
 【 スタック構築順序に関して 】
 -  AWS CLI でのスタック構築順を [lecture10.md](../../Tasks/lecture10/lecture10.md) より変更　( ※EC2より先にALBを構築するように変更 )
 - これは、`05_cfn-ec2_autoscaling.yml` 内に記載している `AutoScalingGroup - TargetGroupARNs` で、`04_cfn-elb_autoscaling.yml` で記載しているターゲットグループのARNの情報が必要であるため　( ※クロススタック参照にて情報を参照するようにしている )

--- a/terraform/practice02/terraform_files_redundant_configuration/01_vpc.tf
+++ b/terraform/practice02/terraform_files_redundant_configuration/01_vpc.tf
@@ -1,0 +1,139 @@
+# ---------------------------------------------
+# VPC
+# ---------------------------------------------
+resource "aws_vpc" "TerraformVPC" {
+  cidr_block           = "10.0.0.0/16"
+  instance_tenancy     = "default"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-vpc"
+    Project = var.project
+    Env     = var.environment
+  }
+}
+
+# ---------------------------------------------
+# Subnet
+# ---------------------------------------------
+resource "aws_subnet" "PublicSubnet1a" {
+  vpc_id                  = aws_vpc.TerraformVPC.id
+  availability_zone       = "ap-northeast-1a"
+  cidr_block              = "10.0.0.0/20"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-public-subnet-1a"
+    Project = var.project
+    Env     = var.environment
+    Type    = "public"
+  }
+}
+
+resource "aws_subnet" "PublicSubnet1c" {
+  vpc_id                  = aws_vpc.TerraformVPC.id
+  availability_zone       = "ap-northeast-1c"
+  cidr_block              = "10.0.16.0/20"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-public-subnet-1c"
+    Project = var.project
+    Env     = var.environment
+    Type    = "public"
+  }
+}
+
+resource "aws_subnet" "PrivateSubnet1a" {
+  vpc_id                  = aws_vpc.TerraformVPC.id
+  availability_zone       = "ap-northeast-1a"
+  cidr_block              = "10.0.128.0/20"
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-private-subnet-1a"
+    Project = var.project
+    Env     = var.environment
+    Type    = "private"
+  }
+}
+
+resource "aws_subnet" "PrivateSubnet1c" {
+  vpc_id                  = aws_vpc.TerraformVPC.id
+  availability_zone       = "ap-northeast-1c"
+  cidr_block              = "10.0.144.0/20"
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-private-subnet-1c"
+    Project = var.project
+    Env     = var.environment
+    Type    = "private"
+  }
+}
+
+# ---------------------------------------------
+# Route Table
+# ---------------------------------------------
+resource "aws_route_table" "PublicRouteTable" {
+  vpc_id = aws_vpc.TerraformVPC.id
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-public-rtb"
+    Project = var.project
+    Env     = var.environment
+    Type    = "public"
+  }
+}
+
+resource "aws_route_table_association" "PublicSubnet1aRouteTableAssociation" {
+  route_table_id = aws_route_table.PublicRouteTable.id
+  subnet_id      = aws_subnet.PublicSubnet1a.id
+}
+
+resource "aws_route_table_association" "PublicSubnet1cRouteTableAssociation" {
+  route_table_id = aws_route_table.PublicRouteTable.id
+  subnet_id      = aws_subnet.PublicSubnet1c.id
+}
+
+resource "aws_route_table" "PrivateRouteTable" {
+  vpc_id = aws_vpc.TerraformVPC.id
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-private-rtb"
+    Project = var.project
+    Env     = var.environment
+    Type    = "private"
+  }
+}
+
+resource "aws_route_table_association" "PrivateSubnet1aRouteTableAssociation" {
+  route_table_id = aws_route_table.PrivateRouteTable.id
+  subnet_id      = aws_subnet.PrivateSubnet1a.id
+}
+
+resource "aws_route_table_association" "PrivateSubnet1cRouteTableAssociation" {
+  route_table_id = aws_route_table.PrivateRouteTable.id
+  subnet_id      = aws_subnet.PrivateSubnet1c.id
+}
+
+# ---------------------------------------------
+# Internet Gateway
+# ---------------------------------------------
+resource "aws_internet_gateway" "TerraformInternetGateway" {
+  vpc_id = aws_vpc.TerraformVPC.id
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-igw"
+    Project = var.project
+    Env     = var.environment
+  }
+}
+
+resource "aws_route" "PublicRoute" {
+  route_table_id         = aws_route_table.PublicRouteTable.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.TerraformInternetGateway.id
+}
+

--- a/terraform/practice02/terraform_files_redundant_configuration/02_securitygroup.tf
+++ b/terraform/practice02/terraform_files_redundant_configuration/02_securitygroup.tf
@@ -1,0 +1,113 @@
+# ---------------------------------------------
+# Security Group
+# ---------------------------------------------
+# sg for EC2-WebServer
+resource "aws_security_group" "EC2SecurityGroup" {
+  name        = "${var.project}-${var.environment}-EC2-WebServer-sg"
+  description = "sg for EC2-WebServer"
+  vpc_id      = aws_vpc.TerraformVPC.id
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-EC2-WebServer-sg"
+    Project = var.project
+    Env     = var.environment
+  }
+}
+
+resource "aws_security_group_rule" "ec2_web_in_http_from_ALB" {
+  security_group_id        = aws_security_group.EC2SecurityGroup.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 80
+  to_port                  = 80
+  source_security_group_id = aws_security_group.ALBSecurityGroup.id
+}
+
+resource "aws_security_group_rule" "ec2_web_in_ssh" {
+  security_group_id = aws_security_group.EC2SecurityGroup.id
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 22
+  to_port           = 22
+  cidr_blocks       = [data.aws_ssm_parameter.myIP-terraform.value] # パラメータストアの暗号化した値を取得
+}
+
+resource "aws_security_group_rule" "ec2_web_in_tcp3000" {
+  security_group_id = aws_security_group.EC2SecurityGroup.id
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 3000
+  to_port           = 3000
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "web_egress" {
+  security_group_id = aws_security_group.EC2SecurityGroup.id
+  type              = "egress"
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+# sg for RDS-MySQL
+resource "aws_security_group" "RDSSecurityGroup" {
+  name        = "${var.project}-${var.environment}-RDS-MySQL-sg"
+  description = "sg for RDS-MySQL"
+  vpc_id      = aws_vpc.TerraformVPC.id
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-RDS-MySQL-sg"
+    Project = var.project
+    Env     = var.environment
+  }
+}
+
+resource "aws_security_group_rule" "rds_in_tcp3306_from_ec2" {
+  security_group_id        = aws_security_group.RDSSecurityGroup.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 3306
+  to_port                  = 3306
+  source_security_group_id = aws_security_group.EC2SecurityGroup.id
+}
+
+resource "aws_security_group_rule" "rds_egress" {
+  security_group_id = aws_security_group.RDSSecurityGroup.id
+  type              = "egress"
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+# sg for ALB
+resource "aws_security_group" "ALBSecurityGroup" {
+  name        = "${var.project}-${var.environment}-ALB-sg"
+  description = "sg for ALB"
+  vpc_id      = aws_vpc.TerraformVPC.id
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-ALB-sg"
+    Project = var.project
+    Env     = var.environment
+  }
+}
+
+resource "aws_security_group_rule" "alb_in_http" {
+  security_group_id = aws_security_group.ALBSecurityGroup.id
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+resource "aws_security_group_rule" "alb_egress" {
+  security_group_id = aws_security_group.ALBSecurityGroup.id
+  type              = "egress"
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+  

--- a/terraform/practice02/terraform_files_redundant_configuration/03_rds_multiaz.tf
+++ b/terraform/practice02/terraform_files_redundant_configuration/03_rds_multiaz.tf
@@ -1,0 +1,53 @@
+# ---------------------------------------------
+# RDS subnet group
+# ---------------------------------------------
+# DB Subnet Group for Private
+resource "aws_db_subnet_group" "RDSDBSubnetGroup" {
+  name        = "${var.project}-${var.environment}-rds-mysql-private-subnetgroup"
+  description = "DB Subnet Group for Private Subnet"
+
+  subnet_ids = [
+    aws_subnet.PrivateSubnet1a.id,
+    aws_subnet.PrivateSubnet1c.id
+  ]
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-RDS-MySQL-private-subnetgroup"
+    Project = var.project
+    Env     = var.environment
+  }
+}
+
+# ---------------------------------------------
+# RDS instance
+# ---------------------------------------------
+resource "aws_db_instance" "RDSDBInstance" {
+  engine                      = "mysql"
+  engine_version              = "8.0.32"
+  identifier                  = "${var.project}-${var.environment}-rds-mysql"
+  username                    = data.aws_ssm_parameter.MasterUsername-terraform.value # パラメータストアの暗号化した値を取得
+  manage_master_user_password = true                                                  # SecretsManager でのマスターパスワードの管理を有効化
+  instance_class              = "db.t3.micro"
+  allocated_storage           = 20
+  storage_type                = "gp2"
+  storage_encrypted           = true
+  multi_az                    = true
+  #availability_zone           = "ap-northeast-1a" #DBインスタンスがマルチ AZ デプロイの場合、AZの指定ができない (AWS公式ドキュメントより)
+  db_subnet_group_name       = aws_db_subnet_group.RDSDBSubnetGroup.name
+  vpc_security_group_ids     = [aws_security_group.RDSSecurityGroup.id]
+  publicly_accessible        = false
+  port                       = 3306
+  db_name                    = "terraform"
+  copy_tags_to_snapshot      = true
+  backup_retention_period    = 0
+  auto_minor_version_upgrade = true
+  deletion_protection        = false
+  skip_final_snapshot        = true
+  apply_immediately          = false
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-rds-mysql"
+    Project = var.project
+    Env     = var.environment
+  }
+}

--- a/terraform/practice02/terraform_files_redundant_configuration/04_ec2_autoscaling.tf
+++ b/terraform/practice02/terraform_files_redundant_configuration/04_ec2_autoscaling.tf
@@ -1,0 +1,92 @@
+# # ---------------------------------------------
+# # EC2 Instance
+# # ---------------------------------------------
+# resource "aws_instance" "EC2WebServer01" {
+#   ami = data.aws_ami.EC2WebServer01.id
+#   #ami                         = var.ami   # 第5回サンプルアプリのAMIを使用しての動作確認用
+#   instance_type               = "t2.micro"
+#   subnet_id                   = aws_subnet.PublicSubnet1a.id
+#   associate_public_ip_address = true
+#   iam_instance_profile        = aws_iam_instance_profile.EC2InstanceProfile.name # SessionManager を適用
+#   vpc_security_group_ids = [
+#     aws_security_group.EC2SecurityGroup.id,
+#   ]
+#   key_name = data.aws_ssm_parameter.KeyName-terraform.value # パラメータストアの暗号化した値を取得
+
+#   tags = {
+#     Name    = "${var.project}-${var.environment}-EC2WebServer01"
+#     Project = var.project
+#     Env     = var.environment
+#     Type    = "web/app"
+#   }
+# }
+
+# ---------------------------------------------
+# launch template
+# ---------------------------------------------
+resource "aws_launch_template" "EC2LaunchTemplate" {
+  update_default_version = true
+  name                   = "${var.project}-${var.environment}-LaunchTemplate"
+  image_id               = data.aws_ami.EC2WebServer01.id
+  instance_type          = "t2.micro"
+  key_name               = data.aws_ssm_parameter.KeyName-terraform.value # パラメータストアの暗号化した値を取得
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name    = "${var.project}-${var.environment}-EC2WebServer"
+      Project = var.project
+      Env     = var.environment
+      Type    = "app"
+    }
+  }
+
+  network_interfaces {
+    associate_public_ip_address = true
+    security_groups = [
+      aws_security_group.EC2SecurityGroup.id,
+    ]
+    delete_on_termination = true
+  }
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.EC2InstanceProfile.name # SessionManager を適用
+  }
+
+  user_data = filebase64("./04_ec2_userdata.sh")
+}
+
+# ---------------------------------------------
+# auto scaling group
+# ---------------------------------------------
+resource "aws_autoscaling_group" "AutoScalingGroup" {
+  name = "${var.project}-${var.environment}-AutoScalingGroup"
+
+  min_size         = 2
+  max_size         = 4
+  desired_capacity = 2
+
+  health_check_type         = "ELB"
+  health_check_grace_period = 300
+  protect_from_scale_in     = false
+
+  vpc_zone_identifier = [
+    aws_subnet.PublicSubnet1a.id,
+    aws_subnet.PublicSubnet1c.id
+  ]
+
+  target_group_arns = [aws_lb_target_group.ALBTargetGroup.arn]
+
+  mixed_instances_policy {
+    launch_template {
+      launch_template_specification {
+        launch_template_id = aws_launch_template.EC2LaunchTemplate.id
+        version            = "$Latest"
+      }
+      # # 起動テンプレートの情報を上書き
+      # override {
+      #   instance_type = "t2.micro"
+      # }
+    }
+  }
+}

--- a/terraform/practice02/terraform_files_redundant_configuration/04_ec2_userdata.sh
+++ b/terraform/practice02/terraform_files_redundant_configuration/04_ec2_userdata.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+# ---------------------------------
+# EC2 user data：Autoscaling (ALBヘルスチェック対応)・RDS接続等確認用
+# ---------------------------------
+sudo yum update -y
+sudo yum -y install httpd
+
+sudo touch /var/www/html/index.html
+
+sudo systemctl enable httpd
+sudo systemctl start httpd
+
+sudo yum -y remove mariadb-libs
+sudo yum localinstall -y https://dev.mysql.com/get/mysql80-community-release-el7-7.noarch.rpm
+sudo yum install -y mysql-community-server mysql-community-devel
+
+sudo systemctl enable mysqld
+sudo systemctl start mysqld

--- a/terraform/practice02/terraform_files_redundant_configuration/05_iam.tf
+++ b/terraform/practice02/terraform_files_redundant_configuration/05_iam.tf
@@ -1,0 +1,29 @@
+# ---------------------------------------------
+# IAM Role：EC2 - SessionManager 適用のため記述
+# ---------------------------------------------
+resource "aws_iam_instance_profile" "EC2InstanceProfile" {
+  name = aws_iam_role.EC2IAMRole.name
+  role = aws_iam_role.EC2IAMRole.name
+}
+
+resource "aws_iam_role" "EC2IAMRole" {
+  name               = "${var.project}-${var.environment}-SSM-role"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
+}
+
+data "aws_iam_policy_document" "ec2_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "EC2IAMRole_ssm_managed" {
+  role       = aws_iam_role.EC2IAMRole.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+  

--- a/terraform/practice02/terraform_files_redundant_configuration/06_elb_autoscaling.tf
+++ b/terraform/practice02/terraform_files_redundant_configuration/06_elb_autoscaling.tf
@@ -1,0 +1,63 @@
+# ---------------------------------------------
+# ALB
+# ---------------------------------------------
+resource "aws_lb" "ALB" {
+  name               = "${var.project}-${var.environment}-ALB"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups = [
+    aws_security_group.ALBSecurityGroup.id
+  ]
+  subnets = [
+    aws_subnet.PublicSubnet1a.id,
+    aws_subnet.PublicSubnet1c.id
+  ]
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-ALB"
+    Project = var.project
+    Env     = var.environment
+  }
+}
+
+resource "aws_lb_listener" "ALBListener_http" {
+  load_balancer_arn = aws_lb.ALB.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.ALBTargetGroup.arn
+  }
+}
+
+# ---------------------------------------------
+# target group
+# ---------------------------------------------
+resource "aws_lb_target_group" "ALBTargetGroup" {
+  name        = "${var.project}-${var.environment}-ALB-tg"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.TerraformVPC.id
+  target_type = "instance"
+
+  health_check {
+    enabled             = true
+    path                = "/"
+    interval            = 10
+    healthy_threshold   = 2
+    timeout             = 5
+    unhealthy_threshold = 2
+  }
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-ALB-tg"
+    Project = var.project
+    Env     = var.environment
+  }
+}
+
+# resource "aws_lb_target_group_attachment" "instance" {
+#   target_group_arn = aws_lb_target_group.ALBTargetGroup.arn
+#   target_id        = aws_instance.EC2WebServer01.id
+# }

--- a/terraform/practice02/terraform_files_redundant_configuration/07_s3.tf
+++ b/terraform/practice02/terraform_files_redundant_configuration/07_s3.tf
@@ -1,0 +1,27 @@
+# S3 bucket 名にランダム文字列を使用するための記述
+resource "random_string" "s3_unique_key" {
+  length  = 6
+  upper   = false
+  lower   = true
+  numeric = true
+  special = false
+}
+
+# ---------------------------------------------
+# S3 bucket
+# ---------------------------------------------
+resource "aws_s3_bucket" "S3Bucket" {
+  bucket = "${var.project}-${var.environment}-bucket-${random_string.s3_unique_key.result}"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "S3Bucket" {
+  bucket = aws_s3_bucket.S3Bucket.id
+
+  rule {
+    bucket_key_enabled = true
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+  

--- a/terraform/practice02/terraform_files_redundant_configuration/data.tf
+++ b/terraform/practice02/terraform_files_redundant_configuration/data.tf
@@ -1,0 +1,41 @@
+# ---------------------------------------------
+# SSM：パラメータストアの暗号化した値を取得
+# ---------------------------------------------
+data "aws_ssm_parameter" "myIP-terraform" {
+  name            = "/myIP-terraform" # パラメータの名前/パスを指定
+  with_decryption = true
+}
+
+data "aws_ssm_parameter" "MasterUsername-terraform" {
+  name            = "/MasterUsername-terraform" # パラメータの名前/パスを指定
+  with_decryption = true
+}
+
+data "aws_ssm_parameter" "KeyName-terraform" {
+  name            = "/KeyName-terraform" # パラメータの名前/パスを指定
+  with_decryption = true
+}
+
+# ---------------------------------------------
+# AMI：Amazon Linux 2 の最新のAMIを動的取得
+# ---------------------------------------------
+# 事前に AWS CLI で該当のAMI情報を確認し、必要な情報を抽出 (下記記述に反映)
+data "aws_ami" "EC2WebServer01" {
+  most_recent = true # 最新のものを選択
+  owners      = ["self", "amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-2.0.*-x86_64-gp2"]
+    #values = ["amzn2-ami-kernel-5.10-hvm-2.0.*-x86_64-gp2"]
+  }
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+  

--- a/terraform/practice02/terraform_files_redundant_configuration/main.tf
+++ b/terraform/practice02/terraform_files_redundant_configuration/main.tf
@@ -1,0 +1,64 @@
+# ---------------------------------------------
+# Terraform configuration
+# ---------------------------------------------
+terraform {
+  required_version = ">=1.5.0"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      #version = "~> 3.0" # 確認用
+      #version = "~> 4.0" # 確認用
+      version = "~> 5.0"
+    }
+  }
+}
+
+# ---------------------------------------------
+# Provider
+# ---------------------------------------------
+provider "aws" {
+  #profile = var.profile #確認用
+  region = "ap-northeast-1"
+}
+
+# ---------------------------------------------
+# Backend：S3
+# ---------------------------------------------
+# ※【補足】 初期化実行時、バックエンド設定(記述)では variables が使用できないため、
+# 　ハードコーディングを避ける方法としては terraform init コマンド実行時に引数を渡す方法がある
+# ---------------------------------------------
+terraform {
+  backend "s3" {
+    #profile = var.profile # 確認用
+    bucket = "aws-work-terraform-practice02"
+    key    = "dev/terraform.tfstate"
+    region = "ap-northeast-1"
+  }
+}
+
+# 確認用 (※上記記述をコメントアウト、terrafrom init コマンドに引数を渡して初期化を実行)
+#   terraform {
+#     backend "s3" {
+#     }
+#   }
+
+# ---------------------------------------------
+# Variables
+# ---------------------------------------------
+variable "project" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+# 確認用
+# variable "profile" {
+#   type = string
+# }
+
+# 第5回サンプルアプリのAMIを使用しての動作確認用
+# variable "ami" {
+#   type = string
+# }

--- a/terraform/practice02/tf_practice02.md
+++ b/terraform/practice02/tf_practice02.md
@@ -1,0 +1,117 @@
+# 【 Terraform：冗長化構成 ( redundant configuration ) に変更 】
+
+## ■ 構成図
+ - 変更前　( シングルAZ構成 )
+ ![resource_diagram.png](../../Tasks/lecture10/images/resource_diagram.png)
+
+- 変更後　( マルチAZ構成 )
+  ![cfn-practice01.png](../../cloudformation/practice01/images/cfn-practice01.png)
+
+## ■ インフラリソースの追加・設定変更
+- [tf_practice01.md (シングルAZ構成)](../practice01/tf_practice01.md) で作成した既存の [terraform_files](../practice01/terraform_files) に、上図の マルチAZ・冗長化構成 となるよう下記内容を追記・修正　( ※ [cfn_practice01.md ( マルチAZ・冗長化構成 )](../../cloudformation/practice01/cfn_practice01.md) と同様の内容のリソース構築を Terraform にて実施 )
+  - EC2 - シングルAZ から マルチAZ配置<br>
+  ( ※起動テンプレートを作成、AutoScalingに適用してEC2を起動 )<br>
+  ( ※既存のEC2の記述は削除 (コメントアウト) )
+  - RDS - シングルAZ から マルチAZ配置　( ※MautiAZの有効化 )
+- 作成後の tfファイル：[terraform_files_redundant_configuration](./terraform_files_redundant_configuration)
+
+## ■ Terraform CLI で下記コマンドを実行してリソース構築
+```
+$ pwd
+/terraform_files_redundant_configuration
+
+$ aws-vault exec <プロファイル名>  # subshell が起動、MFAコードを入力
+
+$ terraform init  #初期化
+
+$ terraform plan  #ドライラン
+
+$ terraform apply -auto-approve  #リソース構築
+```
+
+## ■ 作成リソース
+- [terraform_files_redundant_configuration](./terraform_files_redundant_configuration) - ファイル構成
+```
+terraform_files_redundant_configuration
+|-- 01_vpc.tf
+|-- 02_securitygroup.tf
+|-- 03_rds_multiaz.tf      # MautiAZを有効化
+|-- 04_ec2_autoscaling.tf  # 起動テンプレート・AutoScaling
+|-- 04_ec2_userdata.sh  　 # Autoscaling (ALBヘルスチェック対応)・RDS接続等確認用
+|-- 05_iam.tf
+|-- 06_elb_autoscaling.tf  # 起動テンプレート・AutoscalingによるEC2起動に伴う記述修正
+|-- 07_s3.tf
+|-- data.tf
+|-- main.tf
+`-- terraform.tfvars
+```
+- 構築リソース
+```
+$ terraform state list
+
+data.aws_ami.EC2WebServer01
+data.aws_iam_policy_document.ec2_assume_role
+data.aws_ssm_parameter.KeyName-terraform
+data.aws_ssm_parameter.MasterUsername-terraform
+data.aws_ssm_parameter.myIP-terraform
+aws_autoscaling_group.AutoScalingGroup
+aws_db_instance.RDSDBInstance
+aws_db_subnet_group.RDSDBSubnetGroup
+aws_iam_instance_profile.EC2InstanceProfile
+aws_iam_role.EC2IAMRole
+aws_iam_role_policy_attachment.EC2IAMRole_ssm_managed
+aws_internet_gateway.TerraformInternetGateway
+aws_launch_template.EC2LaunchTemplate
+aws_lb.ALB
+aws_lb_listener.ALBListener_http
+aws_lb_target_group.ALBTargetGroup
+aws_route.PublicRoute
+aws_route_table.PrivateRouteTable
+aws_route_table.PublicRouteTable
+aws_route_table_association.PrivateSubnet1aRouteTableAssociation
+aws_route_table_association.PrivateSubnet1cRouteTableAssociation
+aws_route_table_association.PublicSubnet1aRouteTableAssociation
+aws_route_table_association.PublicSubnet1cRouteTableAssociation
+aws_s3_bucket.S3Bucket
+aws_s3_bucket_server_side_encryption_configuration.S3Bucket
+aws_security_group.ALBSecurityGroup
+aws_security_group.EC2SecurityGroup
+aws_security_group.RDSSecurityGroup
+aws_security_group_rule.alb_egress
+aws_security_group_rule.alb_in_http
+aws_security_group_rule.ec2_web_in_http_from_ALB
+aws_security_group_rule.ec2_web_in_ssh
+aws_security_group_rule.ec2_web_in_tcp3000
+aws_security_group_rule.rds_egress
+aws_security_group_rule.rds_in_tcp3306_from_ec2
+aws_security_group_rule.web_egress
+aws_subnet.PrivateSubnet1a
+aws_subnet.PrivateSubnet1c
+aws_subnet.PublicSubnet1a
+aws_subnet.PublicSubnet1c
+aws_vpc.TerraformVPC
+random_string.s3_unique_key
+```
+## ■ 検証・動作確認・工夫点・備忘録
+【 AutoScaling を使用した EC2 の起動に関して 】
+- 起動テンプレート・AutoScalingを使用してEC2を起動する際、ALBのヘルスチェックが Unhealty だと EC2 が起動と終了を繰り返してしまう
+- そのため、起動テンプレートが参照するユーザデータファイル `04_ec2_userdata.sh` に、 `httpd` をインストールして空の `index.html` を `/var/www/html` 配下に作成する記述を行いヘルスチェックが通るよう対応<br>
+
+【 EC2 / RDS の接続・データ同期等の確認に関して 】
+- EC2へは SessionManager にて接続
+- その後、EC2 から RDS への接続確認は MySQLコマンド にてログインを実施　( ※RDSのエンドポイントを指定してログイン )
+- その際にDB・テーブル・レコードを作成し、他AZ配置のEC2より作成されたRDSのレコードが参照できるかを確認
+- 上記状態で RDS をフェイルオーバーして再起動を実施、スタンバイ(Slave)側のAZに切り替わっていることを確認<br>( ※RDSのイベントログも確認 )
+- その後、各AZに配置されている EC2 より再度 RDS へ MySQLコマンド にてログイン
+- 作成したレコードが参照できることを確認し、データが アクティブ(Master) / スタンバイ(Slave) で同期されていることを確認
+
+## ■ 参考リンク
+- Terraform公式ドキュメント関連
+  - [Resource: aws_db_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance)
+  - [Resource: aws_launch_template](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template#instance_type)
+  - [Resource: aws_lb_target_group_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment)
+  - [Resource: aws_autoscaling_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#mixed_instances_policy)
+- AWS公式ドキュメント関連
+  - [AWS::RDS::DBInstance](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbinstance.html)
+  - [AWS::RDS::DBInstance](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbinstance.html)
+  - [Use instance scale-in protection](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-instance-protection.html)

--- a/terraform/practice02/tf_practice02.md
+++ b/terraform/practice02/tf_practice02.md
@@ -36,8 +36,8 @@ terraform_files_redundant_configuration
 |-- 01_vpc.tf
 |-- 02_securitygroup.tf
 |-- 03_rds_multiaz.tf      # MautiAZを有効化
-|-- 04_ec2_autoscaling.tf  # 起動テンプレート・AutoScaling
-|-- 04_ec2_userdata.sh  　 # Autoscaling (ALBヘルスチェック対応)・RDS接続等確認用
+|-- 04_ec2_autoscaling.tf  # 起動テンプレート作成・AutoScaling設定
+|-- 04_ec2_userdata.sh  　 # Autoscaling(ALBヘルスチェック対応)・RDS接続等確認用
 |-- 05_iam.tf
 |-- 06_elb_autoscaling.tf  # 起動テンプレート・AutoscalingによるEC2起動に伴う記述修正
 |-- 07_s3.tf
@@ -45,7 +45,7 @@ terraform_files_redundant_configuration
 |-- main.tf
 `-- terraform.tfvars
 ```
-- 構築リソース
+- 構築リソース　( 下記コマンドを実行して作成されたリソース一覧を表示 )
 ```
 $ terraform state list
 
@@ -112,6 +112,5 @@ random_string.s3_unique_key
   - [Resource: aws_lb_target_group_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment)
   - [Resource: aws_autoscaling_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#mixed_instances_policy)
 - AWS公式ドキュメント関連
-  - [AWS::RDS::DBInstance](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbinstance.html)
   - [AWS::RDS::DBInstance](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbinstance.html)
   - [Use instance scale-in protection](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-instance-protection.html)


### PR DESCRIPTION
- tf_practice01.md (シングルAZ構成) で作成した既存の terraform_filesを、マルチAZ・冗長化構成 となるよう変更
- 変更後の terraform_files ：terraform_files_redundant_configuration
- ファイル構成
  ```
  terraform_files_redundant_configuration
  |-- 01_vpc.tf
  |-- 02_securitygroup.tf
  |-- 03_rds_multiaz.tf      # MautiAZを有効化
  |-- 04_ec2_autoscaling.tf  # 起動テンプレート作成・AutoScaling設定
  |-- 04_ec2_userdata.sh  　 # Autoscaling(ALBヘルスチェック対応)・RDS接続等確認用
  |-- 05_iam.tf
  |-- 06_elb_autoscaling.tf  # 起動テンプレート・AutoscalingによるEC2起動に伴う記述修正
  |-- 07_s3.tf
  |-- data.tf
  |-- main.tf
  `-- terraform.tfvars
  ```